### PR TITLE
Fix receiving items cheated through !getitem

### DIFF
--- a/Client.py
+++ b/Client.py
@@ -207,8 +207,9 @@ class PsychonautsContext(CommonContext):
         # to manually collect the local items again.
         psy_location_id = ap_location_id - AP_LOCATION_OFFSET
         if psy_location_id not in self.local_psy_location_to_local_psy_item_id:
-            # This should not happen unless AP can send dummy local location IDs for locations that do not exist.
-            logger.error("Error: Local item received from non-existent local location '%s'", ap_location_id)
+            print(f"Local item {ap_item_id} ({base_psy_item_id}) received from non-existent local location"
+                  f" {ap_location_id}. Sending as a non-local item instead.")
+            self.receive_non_local_item(index, base_psy_item_id)
             return
 
         # Get the Psychonauts item id for the item at this local location.


### PR DESCRIPTION
Unlike cheating items with the /send server command which sends from slot 0, items cheated through !getitem send from the current player's slot, which makes them look like locally placed items. These cheated items still need to be received by the player, so they are now sent to the game as if they had been received from another world.