### PR TITLE
Add MentalCobwebShuffle and StartingCobwebDuster options

### DIFF
--- a/Locations.py
+++ b/Locations.py
@@ -505,6 +505,108 @@ deep_arrowhead_locations = {
     **CABH_Deep_Arrowhead_Checks,
 }
 
+# Mental Cobweb locations.
+# These are not included in PsychoRando seed generation so the IDs must be greater than all locations which are included
+# in PsychoRando seed generation.
+# The Cobwebs for each level are ordered by their internal names in Psychonauts, so sometimes the order of the Cobwebs
+# is a bit weird.
+BB_Cobweb_Checks = {
+    LocationName.CobwebTrapezeCobweb: 552,
+    LocationName.CobwebTightropeTutorial: 553,
+    LocationName.CobwebGrindrailWall: 554,
+    LocationName.CobwebBunnyRoomDoor: 555,
+    LocationName.CobwebTunnelOfLogsEnd: 556,
+}
+
+SA_Cobweb_Checks = {
+    LocationName.CobwebBlockArchLeft: 557,
+    LocationName.CobwebBlockArchRight: 558,
+    LocationName.CobwebBackOfShoeboxTower: 559,
+    LocationName.CobwebShoeboxTower: 560,
+    LocationName.CobwebFlameTowerArch: 561,
+}
+
+MI_Cobweb_Checks = {
+    LocationName.CobwebIntroStatueCorner: 562,
+    LocationName.CobwebBehindPinballLadder: 563,
+    LocationName.CobwebGrindrailRings: 564,
+    LocationName.CobwebFanRoomEntrance: 565,
+    LocationName.CobwebPartyRoomFloor: 566,
+}
+
+BT_Cobweb_Checks = {
+    LocationName.CobwebBathtubDrain: 567,
+    LocationName.CobwebForestPathThorns: 568,
+    LocationName.CobwebForestHighPlatform: 569,
+    LocationName.CobwebShadowMonsterMeat: 570,
+    LocationName.CobwebThornTowerRight: 571,
+}
+
+LO_Cobweb_Checks = {
+    LocationName.CobwebSkyscraperBeforeDam: 572,
+    LocationName.CobwebSkyscrapersBeforeTunnel: 573,
+    LocationName.CobwebBehindLasers: 574,
+    LocationName.CobwebEndOfDam: 575,
+    LocationName.CobwebGroundAfterBridge: 576,
+}
+
+MM_Cobweb_Checks = {
+    LocationName.CobwebThirdHouse: 577,
+    LocationName.CobwebPostOfficeLobby: 578,
+    LocationName.CobwebRightHouseBeforePostOffice: 579,
+    LocationName.CobwebWebbedGarage: 580,
+    LocationName.CobwebBookDepository: 581,
+}
+
+TH_Cobweb_Checks = {
+    LocationName.CobwebBackstageCorridor: 582,
+    LocationName.CobwebBelowTeleporter: 583,
+    LocationName.CobwebStorageRoomLeft: 584,
+    LocationName.CobwebInTheAudience: 585,
+    LocationName.CobwebBelowTheCritic: 586,
+    LocationName.CobwebBehindStage: 587,
+    LocationName.CobwebStorageRoomRight: 588,
+}
+
+WW_Cobweb_Checks = {
+    LocationName.CobwebBeneathSmallArch: 589,
+    LocationName.CobwebBlacksmithsRightBuildingWindow: 590,
+    LocationName.CobwebBlacksmithsLeftBuilding: 591,
+    LocationName.CobwebBlacksmithsRightBuildingRoof: 592,
+    LocationName.CobwebCarpentersHouse: 593,
+    LocationName.CobwebFredsHouseBasement: 594,
+    LocationName.CobwebUnderTheGuillotine: 595,
+}
+
+BV_Cobweb_Checks = {
+    LocationName.CobwebDiegosHouseGrindrail: 596,
+    LocationName.CobwebDiegosHouse: 597,
+    LocationName.CobwebSewerShowerTunnel: 598,
+    LocationName.CobwebAboveQueenOfHearts: 599,
+    LocationName.CobwebSewerBeforeGate: 600,
+    LocationName.CobwebDiegosHouseFireplace: 601,
+    LocationName.CobwebNearDiegosHouse: 602,
+}
+
+MC_Cobweb_Checks = {
+    LocationName.CobwebTunnelOfLoveOllieEscortExit: 603,
+    LocationName.CobwebEntranceHall1: 604,
+    LocationName.CobwebEntranceHall2: 605,
+}
+
+mental_cobweb_locations = {
+    **BB_Cobweb_Checks,
+    **SA_Cobweb_Checks,
+    **MI_Cobweb_Checks,
+    **BT_Cobweb_Checks,
+    **LO_Cobweb_Checks,
+    **MM_Cobweb_Checks,
+    **TH_Cobweb_Checks,
+    **WW_Cobweb_Checks,
+    **BV_Cobweb_Checks,
+    **MC_Cobweb_Checks,
+}
+
 # Includes locations that may not be enabled.
 all_fillable_locations = {
     **CA_Checks,
@@ -521,6 +623,7 @@ all_fillable_locations = {
     **BV_Checks,
     **MC_Checks,
     **deep_arrowhead_locations,
+    **mental_cobweb_locations
 }
 
 all_locations = {
@@ -533,6 +636,7 @@ all_locations = {
 # placed.
 _FULLY_REMOTE_LOCATION_IDS = {
     *deep_arrowhead_locations.values(),
+    *mental_cobweb_locations.values()
 }
 # IDs of locations that place items into the game world, and are therefore used in PsychoSeed generation.
 PSYCHOSEED_LOCATION_IDS = set(all_fillable_locations.values())

--- a/Names/LocationName.py
+++ b/Names/LocationName.py
@@ -275,29 +275,44 @@ PoleSwingingTutorial = "(BB Area 2) Pole-Swinging Tutorial"
 TrapezeCobweb = "(BB Area 2) Trapeze Cobweb"
 TrapezePlatform = "(BB Area 2) Trapeze Platform"
 InsidePlaneWreckage = "(BB Area 2) Inside Plane Wreckage"
+CobwebTrapezeCobweb = "(BB Area 2 Cobweb) Trapeze Cobweb"
+CobwebTightropeTutorial = "(BB Area 2 Cobweb) Tightrope Tutorial"
+CobwebGrindrailWall = "(BB Area 2 Cobweb) Grindrail Wall"
 
 # Obstacle Course Finale [BBLT] 
 EndOfObstacleCourseLeft = "(BB Finale) End of Obstacle Course Left"
 EndOfObstacleCourseRight = "(BB Finale) End of Obstacle Course Right"
 BasicBrainingComplete = "(BB Finale) Basic Braining Complete"
+CobwebBunnyRoomDoor = "(BB Finale Cobweb) Bunny Room Door"
+CobwebTunnelOfLogsEnd = "(BB Finale Cobweb) Tunnel of Logs End"
 
-# Sasha's Shooting Gallery [SACU] 
+# Sasha's Shooting Gallery [SACU]
+# Face 1
 OnTheBed = "(SA Main) On the Bed"
 OnThePillow = "(SA Main) On the Pillow"
 BuildingBlocksLeft = "(SA Main) Building Blocks Left"
 BuildingBlocksBelow = "(SA Main) Building Blocks Below"
 BuildingBlocksRight = "(SA Main) Building Blocks Right"
 TopOfBedFrame = "(SA Main) Top of Bed Frame"
+CobwebBlockArchLeft = "(SA Main Cobweb) Block Arch Left"
+CobwebBlockArchRight = "(SA Main Cobweb) Block Arch Right"
+# Face 2
 RoundPlatformsBottom = "(SA Main) Round Platforms Bottom"
 RoundPlatformsNearValve = "(SA Main) Round Platforms Near Valve"
 RoundPlatformsFarFromValve = "(SA Main) Round Platforms Far from Valve"
+# Face 3
 SideOfCubeFace3 = "(SA Main) Side of Cube Face 3"
 BottomOfShoeboxLadder = "(SA Main) Bottom of Shoebox Ladder"
 ShoeboxPedestal = "(SA Main) Shoebox Pedestal"
 ShoeboxTowerTop = "(SA Main) Shoebox Tower Top"
+CobwebBackOfShoeboxTower = "(SA Main Cobweb) Back of Shoebox Tower"
+CobwebShoeboxTower = "(SA Main Cobweb) Shoebox Tower"
+# Face 4
 FlameTowerSteps = "(SA Main) Flame Tower Steps"
 FlameTowerTop1 = "(SA Main) Flame Tower Top 1"
 FlameTowerTop2 = "(SA Main) Flame Tower Top 2"
+CobwebFlameTowerArch = "(SA Main) Flame Tower Arch"
+# Completion
 SashasShootingGalleryComplete = "(SA Main) Sasha's Shooting Gallery Complete"
 
 # The Lounge [MIFL] 
@@ -311,6 +326,9 @@ GrindrailRings = "(MI Area 1) Grindrail Rings"
 CensorHallway = "(MI Area 1) Censor Hallway"
 PinkBowlBottom = "(MI Area 1) Pink Bowl Bottom"
 PinkBowlSmallPlatform = "(MI Area 1) Pink Bowl Small Platform"
+CobwebIntroStatueCorner = "(MI Area 1 Cobweb) Intro Statue Corner"
+CobwebBehindPinballLadder = "(MI Area 1 Cobweb) Behind Pinball Ladder"
+CobwebGrindrailRings = "(MI Area 1 Cobweb) Grindrail Rings"
 
 # The Party [MILL] 
 BubblyFanBottom = "(MI Finale) Bubbly Fan Bottom"
@@ -318,6 +336,8 @@ BubblyFanPlatform = "(MI Finale) Bubbly Fan Platform"
 BubblyFanTop = "(MI Finale) Bubbly Fan Top"
 MillasPartyRoom = "(MI Finale) Milla's Party Room"
 MillasDancePartyComplete = "(MI Finale) Milla's Dance Party Complete"
+CobwebFanRoomEntrance = "(MI Finale Cobweb) Fan Room Entrance"
+CobwebPartyRoomFloor = "(MI Finale Cobweb) Party Room Floor"
 
 # The Nightmare Woods [NIMP] 
 OutsideCaravan = "(BT Main) Outside Caravan"
@@ -333,6 +353,11 @@ ForestPathThorns = "(BT Main) Forest Path Thorns"
 BehindThornTowerLeft = "(BT Main) Behind Thorn Tower Left"
 BehindThornTowerMid = "(BT Main) Behind Thorn Tower Mid"
 BehindThornTowerRight = "(BT Main) Behind Thorn Tower Right"
+CobwebShadowMonsterMeat = "(BT Main Cobweb) Shadow Monster Meat"
+CobwebForestHighPlatform = "(BT Main Cobweb) Forest High Platform"
+CobwebForestPathThorns = "(BT Main Cobweb) Forest Path Thorns"
+CobwebBathtubDrain = "(BT Main Cobweb) Bathtub Drain"
+CobwebThornTowerRight = "(BT Main Cobweb) Thorn Tower Right"
 BrainTumblerExperimentComplete = "(BT Boss) Brain Tumbler Experiment Complete"
 
 # Lungfishopolis City [LOMA] 
@@ -353,6 +378,11 @@ SkyscraperAfterBridge = "(LO Main) Skyscraper after Bridge"
 TunnelSuitcaseTag = "(LO Main) Train Tunnel"
 FinalSkyscrapersLeft = "(LO Main) Final Skyscrapers Left"
 FinalSkyscrapersRight = "(LO Main) Final Skyscrapers Right"
+CobwebSkyscraperBeforeDam = "(LO Main Cobweb) Skyscraper Before Dam"
+CobwebSkyscrapersBeforeTunnel = "(LO Main Cobweb) Skyscrapers Before Tunnel"
+CobwebBehindLasers = "(LO Main Cobweb) Behind Lasers"
+CobwebEndOfDam = "(LO Main Cobweb) End of Dam"
+CobwebGroundAfterBridge = "(LO Main Cobweb) Ground after Bridge"
 
 # Kochamara Arena [LOCB] 
 KochamaraIntroLeft = "(LO Boss) Kochamara Intro Left"
@@ -382,10 +412,15 @@ LandscapersHouseKitchenAmmoUp = "(MM Neighborhood) Landscapers House Kitchen"
 PowerlineIslandSandboxHatboxTag = "(MM Neighborhood) Powerline Island Sandbox"
 PowerlineIslandLeftMemoryVault = "(MM Neighborhood) Powerline Island Left"
 PowerlineIslandRightMaxLives = "(MM Neighborhood) Powerline Island Right"
+CobwebThirdHouse = "(MM Neighborhood Cobweb) Third House"
+CobwebPostOfficeLobby = "(MM Neighborhood Cobweb) Post Office Lobby"
+CobwebRightHouseBeforePostOffice = "(MM Neighborhood Cobweb) Right House before Post Office"
+CobwebWebbedGarage = "(MM Neighborhood Cobweb) Webbed Garage"
 
 # The Neighborhood 2 [MMI2] 
 BehindBookDepositorySteamerTrunk = "(MM Depository) Behind Book Depository"
 MilkmanComplete = "(MM Depository) Milkman Complete"
+CobwebBookDepository = "(MM Depository Cobweb) Book Depository"
 
 # The Stage [THMS] 
 NearTheCriticPurse = "(TH Stage) Near the Critic"
@@ -398,6 +433,13 @@ StorageRoomLeftSteamertrunk = "(TH Stage) Storage Room Left"
 StorageRoomRightLowerSuitcaseTag = "(TH Stage) Storage Room Right Lower"
 StorageRoomRightUpperCandle1 = "(TH Stage) Storage Room Right Upper"
 BonitasRoom = "(TH Stage) Bonita's Room"
+CobwebBackstageCorridor = "(TH Stage Cobweb) Backstage Corridor"
+CobwebBelowTeleporter = "(TH Stage Cobweb) Below Teleporter"
+CobwebStorageRoomLeft = "(TH Stage Cobweb) Storage Room Left"
+CobwebInTheAudience = "(TH Stage Cobweb) In the Audience"
+CobwebBelowTheCritic = "(TH Stage Cobweb) Below the Critic"
+CobwebBehindStage = "(TH Stage Cobweb) Behind Stage"
+CobwebStorageRoomRight = "(TH Stage Cobweb) Storage Room Right"
 
 # The Catwalks [THCW] 
 DoghouseSlicersDufflebagTag = "(TH Catwalks) Doghouse Slicers"
@@ -436,6 +478,13 @@ HelpTheKnight = "(WW Main) Help the Knight"
 HelpVillager2 = "(WW Main) Help Villager 2"
 HelpVillager3 = "(WW Main) Help Villager 3"
 WaterlooWorldComplete = "(WW Main) Waterloo World Complete"
+CobwebBeneathSmallArch = "(WW Main Cobweb) Beneath Small Arch"
+CobwebBlacksmithsRightBuildingWindow = "(WW Main Cobweb) Blacksmith's Right Building Window"
+CobwebBlacksmithsLeftBuilding = "(WW Main Cobweb) Blacksmith's Left Building"
+CobwebBlacksmithsRightBuildingRoof = "(WW Main Cobweb) Blacksmith's Right Building Roof"
+CobwebCarpentersHouse = "(WW Main Cobweb) Carpenter's House"
+CobwebFredsHouseBasement = "(WW Main Cobweb) Fred's House Basement"
+CobwebUnderTheGuillotine = "(WW Main Cobweb) Under the Guillotine"
 
 # Running Against the Bull [BVRB] 
 ClubStreetLadySteamertrunk = "(BV Streets) Club Street Lady"
@@ -451,6 +500,13 @@ DiegosBedSuitcaseTag = "(BV Streets) Diego's Bed"
 DiegosRoomHatbox = "(BV Streets) Diego's Room"
 DiegosHouseGrindrailSuitcase = "(BV Streets) Diego's House Grindrail"
 GrindrailBalconyConfusionAmmoUp = "(BV Streets) Grindrail Balcony"
+CobwebDiegosHouseGrindrail = "(BV Streets Cobweb) Diego's House Grindrail"
+CobwebDiegosHouse = "(BV Streets Cobweb) Diego's House"
+CobwebSewerShowerTunnel = "(BV Streets Cobweb) Sewer Shower Tunnel"
+CobwebAboveQueenOfHearts = "(BV Streets Cobweb) Above Queen of Hearts"
+CobwebSewerBeforeGate = "(BV Streets Cobweb) Sewer Before Gate"
+CobwebDiegosHouseFireplace = "(BV Streets Cobweb) Diego's House Fireplace"
+CobwebNearDiegosHouse = "(BV Streets Cobweb) Near Diego's House"
 
 # Edgar's Sanctuary [BVES] 
 SanctuaryBalconyPurseTag = "(BV Edgar) Sanctuary Balcony"
@@ -474,6 +530,9 @@ TunnelOfLoveStartPurse = "(MC Main) Tunnel of Love Start"
 TunnelOfLoveCornerSuitcase = "(MC Main) Tunnel of Love Corner"
 TunnelOfLoveRailDufflebagTag = "(MC Main) Tunnel of Love Rail"
 NextToTheFatLadyDufflebag = "(MC Main) Next to the Final Door"
+CobwebTunnelOfLoveOllieEscortExit = "(MC Main Cobweb) Tunnel of Love Ollie Escort Exit"
+CobwebEntranceHall1 = "(MC Main Cobweb) Entrance Hall 1"
+CobwebEntranceHall2 = "(MC Main Cobweb) Entrance Hall 2"
 FinalBossEvent = "(MC Boss) Final Boss Defeated"
 
 #Ford's Shop, only a location if Cobweb Duster vanilla

--- a/Options.py
+++ b/Options.py
@@ -87,6 +87,13 @@ class DeepArrowheadShuffle(Toggle):
     default = False
 
 
+class MentalCobwebShuffle(Toggle):
+    """Add Mental Cobweb checks and shuffle an extra PSI Card into the pool for each Mental Cobweb.
+    Mental Cobweb locations must be collecting using the Cobweb Duster."""
+    display_name = "Mental Cobweb Shuffle"
+    default = False
+
+
 @dataclass
 class PsychonautsOptions(PerGameCommonOptions):
     StartingLevitation: StartingLevitation
@@ -101,6 +108,7 @@ class PsychonautsOptions(PerGameCommonOptions):
     BrainsRequired: BrainsRequired
     RequireMeatCircus: RequireMeatCircus
     DeepArrowheadShuffle: DeepArrowheadShuffle
+    MentalCobwebShuffle: MentalCobwebShuffle
 
 
 slot_data_options: List[str] = [
@@ -115,4 +123,5 @@ slot_data_options: List[str] = [
     "BrainsRequired",
     "RequireMeatCircus",
     "DeepArrowheadShuffle",
+    "MentalCobwebShuffle",
 ]

--- a/Options.py
+++ b/Options.py
@@ -13,6 +13,13 @@ class StartingMentalMagnet(Toggle):
     display_name = "Start with Mental Magnet"
     default = True
 
+
+class StartingCobwebDuster(Toggle):
+    """Start with the Cobweb Duster."""
+    display_name = "Start with Cobweb Duster"
+    default = False
+
+
 class RandomStartingMinds(Range):
     """Start with a random number of mind unlocking items."""
     display_name = "Random Starting Minds"
@@ -98,6 +105,7 @@ class MentalCobwebShuffle(Toggle):
 class PsychonautsOptions(PerGameCommonOptions):
     StartingLevitation: StartingLevitation
     StartingMentalMagnet: StartingMentalMagnet
+    StartingCobwebDuster: StartingCobwebDuster
     RandomStartingMinds: RandomStartingMinds
     LootboxVaults: LootboxVaults
     EasyMillaRace: EasyMillaRace

--- a/PsychoRandoItems.py
+++ b/PsychoRandoItems.py
@@ -152,7 +152,8 @@ PSYCHORANDO_ITEM_TABLE = {
     ItemName.DowsingRod: 1,
 
     # 110 Psicards, filler item, increase if adding more positions
-    ItemName.PsiCard: 110,
+    # 54 are added for Cobweb Shuffle
+    ItemName.PsiCard: 110 + 54,
 
     # AP Placeholders, 317 total.
     # These have no corresponding AP item and are assumed to always be last in PsychoRando's item order.

--- a/PsychoSeed.py
+++ b/PsychoSeed.py
@@ -170,6 +170,9 @@ def gen_psy_seed(self: "PSYWorld", output_directory):
     randoseed_parts.append(f"           Ob.deepArrowheadShuffle = {_lua_bool(self.options.DeepArrowheadShuffle)}\n")
     randoseed_parts.append(f"           Ob.randomizeDowsingRod = {_lua_bool(self.options.DeepArrowheadShuffle)}\n")
 
+    # append cobwebShuffle setting
+    randoseed_parts.append(f"           Ob.cobwebShuffle = {_lua_bool(self.options.MentalCobwebShuffle)}\n")
+
     # append Goal settings
     beatoleander = _lua_bool(self.options.Goal == Goal.option_braintank
                              or self.options.Goal == Goal.option_braintank_and_brainhunt)

--- a/Regions.py
+++ b/Regions.py
@@ -14,6 +14,16 @@ from .Locations import (
     CAMA_Deep_Arrowhead_Checks,
     CARE_Deep_Arrowhead_Checks,
     CABH_Deep_Arrowhead_Checks,
+    BB_Cobweb_Checks,
+    SA_Cobweb_Checks,
+    MI_Cobweb_Checks,
+    BT_Cobweb_Checks,
+    LO_Cobweb_Checks,
+    MM_Cobweb_Checks,
+    TH_Cobweb_Checks,
+    WW_Cobweb_Checks,
+    BV_Cobweb_Checks,
+    MC_Cobweb_Checks,
 )
 from .Names import LocationName
 from . import Options
@@ -43,10 +53,10 @@ def place_events(self: "PSYWorld"):
 
 
 def _add_locations_to_existing_region(multiworld: MultiWorld, player: int, region_name: str,
-                                      locations: Dict[str, int]):
+                                      locations: Iterable[str]):
     region = multiworld.get_region(region_name, player)
     region.locations.extend(
-        PSYLocation(player, name, location_id + AP_LOCATION_OFFSET, region) for name, location_id in locations.items()
+        PSYLocation(player, name, all_locations[name] + AP_LOCATION_OFFSET, region) for name in locations
     )
 
 
@@ -55,6 +65,61 @@ def create_deep_arrowhead_locations(multiworld: MultiWorld, player: int):
     _add_locations_to_existing_region(multiworld, player, RegionName.CAMA, CAMA_Deep_Arrowhead_Checks)
     _add_locations_to_existing_region(multiworld, player, RegionName.CARE, CARE_Deep_Arrowhead_Checks)
     _add_locations_to_existing_region(multiworld, player, RegionName.CABH, CABH_Deep_Arrowhead_Checks)
+
+
+def create_mental_cobweb_locations(multiworld: MultiWorld, player: int):
+    _add_locations_to_existing_region(multiworld, player, RegionName.BBA2, BB_Cobweb_Checks)
+    _add_locations_to_existing_region(multiworld, player, RegionName.SACU, SA_Cobweb_Checks)
+    _add_locations_to_existing_region(multiworld, player, RegionName.MIFL, MI_Cobweb_Checks)
+    _add_locations_to_existing_region(multiworld, player, RegionName.NIMPMark, BT_Cobweb_Checks)
+
+    # Lungfishopolis cobwebs are split across two regions.
+    loma_cobwebs = {LocationName.CobwebSkyscraperBeforeDam}
+    # All remaining cobwebs are in LOMAShield.
+    lomashield_cobwebs = set(LO_Cobweb_Checks).difference(loma_cobwebs)
+    _add_locations_to_existing_region(multiworld, player, RegionName.LOMA, loma_cobwebs)
+    _add_locations_to_existing_region(multiworld, player, RegionName.LOMAShield, lomashield_cobwebs)
+
+    # The Milkman Conspiracy cobwebs are split across three regions.
+    mmi2_cobwebs = {LocationName.CobwebBookDepository}
+    mmi1_before_sign_cobwebs = {LocationName.CobwebThirdHouse}
+    # All remaining cobwebs are in MMI1AfterSign.
+    mmi1_after_sign_cobwebs = set(MM_Cobweb_Checks) - mmi2_cobwebs - mmi1_before_sign_cobwebs
+    _add_locations_to_existing_region(multiworld, player, RegionName.MMI1BeforeSign, mmi1_before_sign_cobwebs)
+    _add_locations_to_existing_region(multiworld, player, RegionName.MMI1AfterSign, mmi1_after_sign_cobwebs)
+    _add_locations_to_existing_region(multiworld, player, RegionName.MMI2, mmi2_cobwebs)
+
+    # Gloria's Theater cobwebs are split across three regions.
+    thmslev_cobwebs = {LocationName.CobwebInTheAudience}
+    thmsstorage_cobwebs = {LocationName.CobwebStorageRoomLeft, LocationName.CobwebStorageRoomRight}
+    # All remaining cobwebs are in THMS.
+    thms_cobwebs = set(TH_Cobweb_Checks) - thmslev_cobwebs - thmsstorage_cobwebs
+    _add_locations_to_existing_region(multiworld, player, RegionName.THMS, thms_cobwebs)
+    _add_locations_to_existing_region(multiworld, player, RegionName.THMSLev, thmslev_cobwebs)
+    _add_locations_to_existing_region(multiworld, player, RegionName.THMSStorage, thmsstorage_cobwebs)
+
+    # Waterloo World cobwebs are split across two regions.
+    wwmadusterlev_cobwebs = {LocationName.CobwebBlacksmithsRightBuildingRoof}
+    # All the remaining cobwebs are in WWMA.
+    wwma_cobwebs = set(WW_Cobweb_Checks) - wwmadusterlev_cobwebs
+    _add_locations_to_existing_region(multiworld, player, RegionName.WWMA, wwma_cobwebs)
+    _add_locations_to_existing_region(multiworld, player, RegionName.WWMADusterLev, wwmadusterlev_cobwebs)
+
+    # Black Velvetopia cobwebs are split across two regions.
+    # Technically, these locations could all go in either BVRB or BVRBDuster, but it's more accurate to split the
+    # cobwebs into the physical regions they are located in.
+    bvrbduster_cobwebs = {LocationName.CobwebDiegosHouseFireplace, LocationName.CobwebDiegosHouseGrindrail}
+    # All the remaining cobwebs are in BVRB.
+    bvrb_cobwebs = set(BV_Cobweb_Checks) - bvrbduster_cobwebs
+    _add_locations_to_existing_region(multiworld, player, RegionName.BVRB, bvrb_cobwebs)
+    _add_locations_to_existing_region(multiworld, player, RegionName.BVRBDuster, bvrbduster_cobwebs)
+
+    # Meat Circus cobwebs are split across two regions.
+    mctc_escort_cobwebs = {LocationName.CobwebTunnelOfLoveOllieEscortExit}
+    mctc_cobwebs = set(MC_Cobweb_Checks) - mctc_escort_cobwebs
+    _add_locations_to_existing_region(multiworld, player, RegionName.MCTC, mctc_cobwebs)
+    _add_locations_to_existing_region(multiworld, player, RegionName.MCTCEscort, mctc_escort_cobwebs)
+
 
 
 def create_psyregions(world: MultiWorld, player: int):

--- a/Rules.py
+++ b/Rules.py
@@ -5,7 +5,7 @@ from worlds.generic.Rules import add_item_rule, add_rule
 
 from .Names import LocationName, ItemName, RegionName
 from .Items import BrainJar_Table, local_set
-from .Locations import deep_arrowhead_locations
+from .Locations import deep_arrowhead_locations, mental_cobweb_locations
 
 # I don't know what is going on here, but it works???
 # Thanks Jared :)
@@ -340,6 +340,21 @@ class PsyRules:
             for deep_ah_location_name in deep_arrowhead_locations:
                 location = multiworld.get_location(deep_ah_location_name, player)
                 add_rule(location, has_dowsing_rod)
+
+        if self.world.options.MentalCobwebShuffle:
+            local_only_forbidden.update(mental_cobweb_locations.keys())
+
+            for mental_cobweb_location_name in mental_cobweb_locations:
+                location = multiworld.get_location(mental_cobweb_location_name, player)
+                # For simplicity, the rule is currently added to all mental cobweb locations, but it might be worth
+                # considering skipping adding the rule if the location's region already requires the Cobweb Duster to
+                # access.
+                add_rule(location, self.has_cobwebduster)
+
+            # Extra per-cobweb rules that are not covered by the Region the cobweb is in:
+            # BB Grindrail Wall requires Levitation because the ground around the cobweb is sloped and Raz bounces off
+            # it when falling onto it too fast, so Levitation is need to float down slowly.
+            add_rule(multiworld.get_location(LocationName.CobwebGrindrailWall, player), self.has_levitation)
 
         if local_only_forbidden:
             def forbid_local_only(item: Item):

--- a/__init__.py
+++ b/__init__.py
@@ -178,6 +178,12 @@ class PSYWorld(World):
                 adjusted_item_counts[item] -= 1
                 self.multiworld.push_precollected(self.create_item(item))
 
+        # Pre-collect the Cobweb Duster when starting with it.
+        if self.options.StartingCobwebDuster:
+            # Reduce the count to add to the item pool.
+            adjusted_item_counts[ItemName.CobwebDuster] -= 1
+            self.multiworld.push_precollected(self.create_item(ItemName.CobwebDuster))
+
         # Add items for DeepArrowheadShuffle
         if self.options.DeepArrowheadShuffle:
             self._add_deep_arrowhead_shuffle_items(adjusted_item_counts)

--- a/__init__.py
+++ b/__init__.py
@@ -18,7 +18,7 @@ from .Items import (
     AP_ITEM_OFFSET
 )
 from .ItemUtils import repeated_item_names_gen
-from .Locations import all_locations, AP_LOCATION_OFFSET, deep_arrowhead_locations
+from .Locations import all_locations, AP_LOCATION_OFFSET, deep_arrowhead_locations, mental_cobweb_locations
 from .Names import ItemName, LocationName
 from .Options import Goal, PsychonautsOptions, slot_data_options
 from . import Regions
@@ -153,6 +153,12 @@ class PSYWorld(World):
         item_counts[ItemName.AHSmall] += small_count
         item_counts[ItemName.AHLarge] += large_count
 
+    @staticmethod
+    def _add_mental_cobweb_shuffle_items(item_counts: Dict[str, int]):
+        # A single Mental Cobweb can normally be turned into a PSI Card at the loom in Ford's Sanctuary, so add as many
+        # PSI Cards to the pool as Mental Cobweb Locations.
+        item_counts[ItemName.PsiCard] += len(mental_cobweb_locations)
+
     def create_items(self):
         """
         Fills ItemPool 
@@ -176,6 +182,10 @@ class PSYWorld(World):
         if self.options.DeepArrowheadShuffle:
             self._add_deep_arrowhead_shuffle_items(adjusted_item_counts)
 
+        # Add items for MentalCobwebShuffle
+        if self.options.MentalCobwebShuffle:
+            self._add_mental_cobweb_shuffle_items(adjusted_item_counts)
+
         # Create the initial item pool.
         item_pool = list(map(self.create_item, repeated_item_names_gen(item_dictionary_table, adjusted_item_counts)))
 
@@ -186,7 +196,7 @@ class PSYWorld(World):
         # Add filler/junk items to fill out the remaining locations.
         # If there are more locations remaining than the desired maximum number of filler items to add, also add the
         # Feather and Watering Can junk items to the pool.
-        desired_max_filler = 107  # This is arbitrary based on the maximum of 110 Psi Cards placeable in the game world.
+        desired_max_filler = 107  # This is arbitrary based on the max number of Psi Cards placeable in the game world.
         excess = num_locations_to_fill - desired_max_filler
         if excess >= 1:
             item_pool.append(self.create_item(ItemName.Feather))
@@ -211,6 +221,8 @@ class PSYWorld(World):
 
         if self.options.DeepArrowheadShuffle:
             Regions.create_deep_arrowhead_locations(self.multiworld, self.player)
+        if self.options.MentalCobwebShuffle:
+            Regions.create_mental_cobweb_locations(self.multiworld, self.player)
 
     def set_rules(self):
         """


### PR DESCRIPTION
Adds two new disabled by default options.

Mental Cobweb Shuffle:
Adds collecting Mental Cobwebs as locations and shuffles a PSI Card into the item pool for each Mental Cobweb that exists.

Starting Cobweb Duster:
Pre-collects the Cobweb Duster and removes it from the item pool. Pre-collection is used instead if setting `Ob.startcobweb = TRUE` in the RandoSeed.lua patch file so that the logic functions and PopTracker package do not need to be changed to support the option being enabled.